### PR TITLE
Add optional footer banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Customize your site's classification settings in the ``settings`` module:
 	CLASSIFICATION_BACKGROUND_COLOR = 'green'
     CLASSIFICATION_LINK = '/security'
 
+An optional bottom banner may be added:
+
+    CLASSIFICATION_FOOTER_ENABLED = True
+
+The banners may be disabled with:
+
+    CLASSIFICATION_BANNER_ENABLED = False
+
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Add the classification banner context processor to the ```TEMPLATE_CONTEXT_PROCE
     )
 
 Customize your site's classification settings in the ``settings`` module:
-	
-	CLASSIFICATION_TEXT = 'Unclassified//FOUO'
-	CLASSIFICATION_TEXT_COLOR = 'black'
-	CLASSIFICATION_BACKGROUND_COLOR = 'green'
+
+    CLASSIFICATION_TEXT = 'Unclassified//FOUO'
+    CLASSIFICATION_TEXT_COLOR = 'black'
+    CLASSIFICATION_BACKGROUND_COLOR = 'green'
     CLASSIFICATION_LINK = '/security'
 
 An optional bottom banner may be added:
@@ -58,33 +58,32 @@ Once installed, you can easily add a classification banner to any template on yo
 
 First load the classification banner in your template:
 
-	{% load classification_banner %}
-	
+    {% load classification_banner %}
+
 Then add the banner to your page:
 
-	{% classification_banner %}
-
+    {% classification_banner %}
 
 A full example:
 
-	{% load classification_banner %}
-	<html>
-		<head>
-    		<title>FOO</title>
-		</head>
-		<body>
-			{% classification_banner %}
-		</body>
-	</html>
+    {% load classification_banner %}
+    <html>
+        <head>
+            <title>FOO</title>
+        </head>
+        <body>
+            {% classification_banner %}
+        </body>
+    </html>
 
 You can also override your default settings from any template:
 
     {% load classification_banner %}
-	<html>
-		<head>
-    		<title>FOO - Confidential</title>
-		</head>
-		<body>
-			{% classification_banner classification_text='Confidential' classification_text_color='black' classification_background_color='red'%}
-		</body>
-	</html>
+    <html>
+        <head>
+            <title>FOO - Confidential</title>
+        </head>
+        <body>
+            {% classification_banner classification_text='Confidential' classification_text_color='black' classification_background_color='red'%}
+        </body>
+    </html>

--- a/django_classification_banner/context_processors.py
+++ b/django_classification_banner/context_processors.py
@@ -11,7 +11,8 @@ def classification(request):
         'classification_text_color': getattr(settings, 'CLASSIFICATION_TEXT_COLOR', 'white'),
         'classification_background_color': getattr(settings, 'CLASSIFICATION_BACKGROUND_COLOR', 'green'),
         'classification_banner_enabled': getattr(settings, 'CLASSIFICATION_BANNER_ENABLED', True),
-        'classification_link': getattr(settings, 'CLASSIFICATION_LINK', None)
+        'classification_link': getattr(settings, 'CLASSIFICATION_LINK', None),
+        'classification_footer_enabled': getattr(settings, 'CLASSIFICATION_FOOTER_ENABLED', False)
     }
 
     return ctx

--- a/django_classification_banner/static/django_classification_banner/classification.css
+++ b/django_classification_banner/static/django_classification_banner/classification.css
@@ -13,6 +13,21 @@
     z-index: 1031;
 }
 
+#classification-banner-bottom {
+    border:0;
+    display: table;
+    font-size: 15px;
+    height: 10px;
+    left:0;
+    position:fixed;
+    right:0;
+    text-align: center;
+    bottom:0;
+    margin:0;
+    width: 100%;
+    z-index: 1031;
+}
+
 .classification-banner-text{
     display: table-cell;
     vertical-align: middle;

--- a/django_classification_banner/templates/django_classification_banner/classification.html
+++ b/django_classification_banner/templates/django_classification_banner/classification.html
@@ -7,4 +7,10 @@
 <span id="classification-banner-top">
     <p class="classification-banner-text" style="color:{{ classification_text_color|default:'white'}}; background-color: {{ classification_background_color|default:'green' }}">{% if classification_link %}<a style="color:{{ classification_text_color|default:'white'}};" href="{{ classification_link }}" target="_blank">{{ classification_text|default:'UNCLASSIFIED' }}</a>{% else %}{{ classification_text|default:'UNCLASSIFIED' }}{% endif %}</p>
 </span>
+
+    {% if classification_footer_enabled %}
+    <span id="classification-banner-bottom">
+        <p class="classification-banner-text" style="color:{{ classification_text_color|default:'white'}}; background-color: {{ classification_background_color|default:'green' }}">{% if classification_link %}<a style="color:{{ classification_text_color|default:'white'}};" href="{{ classification_link }}" target="_blank">{{ classification_text|default:'UNCLASSIFIED' }}</a>{% else %}{{ classification_text|default:'UNCLASSIFIED' }}{% endif %}</p>
+    </span>
+    {% endif %}
 {% endif %}

--- a/django_classification_banner/templatetags/classification_banner.py
+++ b/django_classification_banner/templatetags/classification_banner.py
@@ -8,7 +8,7 @@ def classification_banner(context, **kwargs):
     response = dict()
 
     for var in ['classification_text', 'classification_text_color', 'classification_background_color',
-                'classification_banner_enabled', 'classification_link']:
+                'classification_banner_enabled', 'classification_link', 'classification_footer_enabled']:
         response[var] = kwargs.get(var, context.get(var))
 
     return response


### PR DESCRIPTION
Apparently it's common to have both a header and footer banner. This PR adds an optional footer banner set with CLASSIFICATION_FOOTER_ENABLED (defaulting to False).

I've updated the readme with instructions. There's also a separate commit cleaning up some whitespace in the readme.