### PR TITLE
Django 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,21 @@ Add ``django_classification_banner`` to ``INSTALLED_APPS`` in your project's
         'django_classification_banner',
     )
 
-Add the classification banner context processor to the ```TEMPLATE_CONTEXT_PROCESSORS``` setting in your project's
-``settings`` module:
+Add the classification banner context processor to the ```context_processors``` section of the ```TEMPLATES``` setting in your project's ``settings`` module:
 
-    TEMPLATE_CONTEXT_PROCESSORS = (
-        # other context processors
-        'django_classification_banner.context_processors.classification',
-    )
+    TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                # other context processors
+                'django_classification_banner.context_processors.classification',
+            ],
+        },
+    },
+    ]
 
 Customize your site's classification settings in the ``settings`` module:
 	

--- a/django_classification_banner/templates/django_classification_banner/classification.html
+++ b/django_classification_banner/templates/django_classification_banner/classification.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 
 {% if classification_banner_enabled %}


### PR DESCRIPTION
This PR adds support for Django 3.x.

Updates include:
- Template uses `load static` instead of `load staticfiles` (removed in Django 3)
- Updated README to document Template Context Processor move into the `TEMPLATES` settings module.